### PR TITLE
fix: fix unsafe type conversion from int to float

### DIFF
--- a/agario/engine/Engine.hpp
+++ b/agario/engine/Engine.hpp
@@ -13,6 +13,7 @@
 #include "agario/core/types.hpp"
 #include "agario/core/Entities.hpp"
 #include "agario/engine/GameState.hpp"
+#include "agario/utils/random.hpp"
 #include <thread>
 #include <chrono>
 namespace agario {
@@ -135,7 +136,10 @@ namespace agario {
       state.ticks++;
     }
 
-    void seed(unsigned s) { std::srand(s); }
+    void seed(unsigned s) {
+      this->state.rng.seed(s);
+      std::srand(s);
+    }
 
     Engine(const Engine &) = delete; // no copy constructor
     Engine &operator=(const Engine &) = delete; // no copy assignments
@@ -864,7 +868,8 @@ namespace agario {
 
     template<typename T>
     T random(T min, T max) {
-      return (max - min) * (static_cast<T>(rand()) / static_cast<T>(RAND_MAX)) + min;
+      uniform_distribution<T> dist(min, max);
+      return dist(this->state.rng);
     }
 
     template<typename T>

--- a/agario/engine/GameState.hpp
+++ b/agario/engine/GameState.hpp
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <iomanip>
 #include <memory>
+#include <random>
 
 namespace agario {
 
@@ -23,9 +24,11 @@ namespace agario {
 
     agario::distance arena_width, arena_height;
     agario::tick ticks;
+    std::mt19937_64 rng;
 
     explicit GameState (agario::distance arena_width, agario::distance arena_height) :
-      arena_width(arena_width), arena_height(arena_height), ticks(0) { }
+      arena_width(arena_width), arena_height(arena_height), ticks(0),
+      rng(std::random_device{}()) { }
 
     void clear() {
       players.clear();

--- a/agario/utils/random.hpp
+++ b/agario/utils/random.hpp
@@ -1,0 +1,20 @@
+#include <random>
+#include <type_traits>
+
+#include "agario/core/num_wrapper.hpp"
+
+template<class T>
+using uniform_distribution =
+  typename std::conditional<
+    // if the type T is a floating point derivative
+    // then use the uniform_real_distribution
+    std::is_floating_point<typename T::value_type>::value,
+    std::uniform_real_distribution<typename T::value_type>,
+    // otherwise, if T is an int derivative
+    // use the uniform_int_distribution
+    typename std::conditional<
+      std::is_integral<typename T::value_type>::value,
+      std::uniform_int_distribution<typename T::value_type>,
+      void
+    >::type
+  >::type;


### PR DESCRIPTION
There are a few issues with the uniform random rng strategy previously. The first is that the static_cast from int to float for RAND_MAX is making gcc raise an unsafe conversion warning. The second is that this min-max rescaling of `rand()` is well-known to be an unsound way to generate uniform random numbers due to the non-uniformity of floating point coverage. Much better to rely on the std library for these things.

For context:
```
/home/andy/Projects/research/AgarLE/agario/../agario/engine/Engine.hpp:867:69: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
  867 |       return (max - min) * (static_cast<T>(rand()) / static_cast<T>(RAND_MAX)) + min;
      |                                                      ~~~~~~~~~~~    ^~~~~~~~
/usr/include/stdlib.h:87:18: note: expanded from macro 'RAND_MAX'
   87 | #define RAND_MAX        2147483647
```