### PR TITLE
feat: set a maximum FPS for client binary

### DIFF
--- a/agario/client/client.hpp
+++ b/agario/client/client.hpp
@@ -9,6 +9,7 @@
 #include <agario/bots/bots.hpp>
 
 #include <chrono>
+#include <thread>
 
 #include <string>
 #include <ctime>
@@ -17,6 +18,7 @@
 #define WINDOW_NAME "AgarIO"
 #define DEFAULT_SCREEN_WIDTH 640
 #define DEFAULT_SCREEN_HEIGHT 480
+#define MAX_FPS 60
 
 #define RENDERABLE true
 
@@ -101,12 +103,14 @@ namespace agario {
     }
 
     void game_loop() {
+      long _tick_time = 1000 / MAX_FPS;
+      auto target_tick_time = std::chrono::milliseconds(_tick_time);
       auto before = std::chrono::system_clock::now();
       while (!window->should_close()) {
 
-        auto now = std::chrono::system_clock::now();
-        auto dt = now - before;
-        before = now;
+        auto tick_start = std::chrono::system_clock::now();
+        auto dt = tick_start - before;
+        before = tick_start;
 
         auto &player = engine.player(player_pid);
 
@@ -127,6 +131,12 @@ namespace agario {
         window->swap_buffers();
 
         engine.tick(dt);
+        auto tick_end = std::chrono::system_clock::now();
+        auto tick_time = tick_end - tick_start;
+        auto sleep_time = std::chrono::duration_cast<std::chrono::milliseconds>(target_tick_time - tick_time);
+        if (sleep_time > std::chrono::milliseconds(0)) {
+          std::this_thread::sleep_for(sleep_time);
+        }
       }
     }
 
@@ -144,7 +154,7 @@ namespace agario {
 
     template <typename T>
     void add_bot(int num_bots) {
-      agario::pid pid = 0; 
+      agario::pid pid = 0;
       for (int i = 0; i < num_bots; i++)
         {
           pid = engine.add_player<T>();


### PR DESCRIPTION
Currently the target FPS will be whatever refresh rate the screen session supports. We want to decouple the simulation from wall clock time in order to allow faster than real time simulation on headless nodes which breaks several of these assumptions (no longer have a physical monitor limiting FPS and no longer want real time simulation). This commit represents a first change towards decoupling these clocks.

Specifically, by limiting FPS to 60, we can now safely assume that each tick is at most 1/60th of a second and allows us to convert time-based events to tick-based events (e.g. anti-teaming time limits)